### PR TITLE
partially revert multi user feature

### DIFF
--- a/core/java/android/os/UserManager.java
+++ b/core/java/android/os/UserManager.java
@@ -1139,7 +1139,7 @@ public class UserManager {
      * @return whether the device supports multiple users.
      */
     public static boolean supportsMultipleUsers() {
-        return false;
+        return getMaxSupportedUsers() > 1 && SystemProperties.getBoolean("fw.show_multiuserui", false);;
         /*return getMaxSupportedUsers() > 1
                 && SystemProperties.getBoolean("fw.show_multiuserui",
                 Resources.getSystem().getBoolean(R.bool.config_enableMultiUserUI));*/
@@ -2634,7 +2634,7 @@ public class UserManager {
      * @return a value greater than or equal to 1
      */
     public static int getMaxSupportedUsers() {
-        return 1;
+        return SystemProperties.getInt("fw.max_users", 1);
         /*
         // Don't allow multiple users on certain builds
         if (android.os.Build.ID.startsWith("JVP")) return 1;


### PR DESCRIPTION
Allow users, who really want multi user feature, add it manually by build.prop like this:
fw.show_multiuserui=1
fw.max_users=4

Sry, i dont't know, where you store issue. I write it in my phone repo:
https://github.com/PixelExperience-Devices/device_xiaomi_whyred/issues/2